### PR TITLE
Task: Add finally handler to ensure requests are always cleaned up.

### DIFF
--- a/lib/collapse.js
+++ b/lib/collapse.js
@@ -28,10 +28,12 @@ class RequestCollapsingTransport extends HttpTransport.transport {
     const pending = this[delegate].makeRequest(ctx, opts);
     this[inflight].set(requestKey, pending);
 
-    return pending.then((res) => {
+    // simulate finally block - ensure request is always removed
+    pending.catch(() => {}).then(() => {
       this[inflight].delete(requestKey);
-      return res;
     });
+
+    return pending;
   }
 
   getInflightCount() {


### PR DESCRIPTION
Ensures a request is always removed from the in flight lookup, even if a request errors. 

For example, if Popularity fails to connect to Episodes API, the request objects will not be removed from the lookup. This memory will not be garbage collected (potential leak). 